### PR TITLE
Switch to capture state

### DIFF
--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -64,19 +64,7 @@ chrome.devtools.panels.create(
                                 value: element.toString()
                             };
                         }
-                        else if (element instanceof Element) {
-                            return {
-                                name, 
-                                value: 'DOM Element'
-                            }
-                        }
                         else if (typeof element === "object") {
-                            if (element.hasOwnProperty('$$')) {
-                                return {
-                                    name,
-                                    value: 'Svelte Component'
-                                }
-                            }
                             if (element.constructor) {
                                 if (element.constructor.name === "Object" || element.constructor.name === "Array") {
                                     const value = {};

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -76,7 +76,7 @@ chrome.devtools.panels.create(
                                 else {
                                     return {
                                         name,
-                                        value: element.constructor.name
+                                        value: '<' + element.constructor.name + '>'
                                     }
                                 }
                             }
@@ -128,9 +128,8 @@ chrome.devtools.panels.create(
                                             parsedState[variable] = parseState(state[variable], variable);
                                         }
                                     }
-                                    // we can't handle any object that's not a "true" object or array, so delete from state
                                     else {
-                                        delete state[variable];
+                                        parsedState[variable] = parseState(state[variable], variable)
                                     }
                                 }
                                 else {

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -359,7 +359,7 @@ chrome.devtools.panels.create(
 
                     // capture subsequent DOM changes to update snapshots
                     window.document.addEventListener('dom-changed', (e) => {
-                        // only send message if something changed in SvelteDOM
+                        // only send message if something changed in SvelteDOM or stateObject
                         const currentState = captureRawAppState();
                         const stateChange = JSON.stringify(currentState) !== JSON.stringify(stateHistory[stateHistory.length -1]);
                         if (components.length || insertedNodes.length || deletedNodes.length || stateChange) {
@@ -392,7 +392,7 @@ chrome.devtools.panels.create(
                         addedEventListeners.splice(0, addedEventListeners.length);
                     });
 
-                    // listen for devTool requesting state injections 
+                    // listen for devTool messages
                     window.addEventListener('message', function () {
                         // Only accept messages from the same frame
                         if (event.source !== window) {

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -395,6 +395,7 @@ chrome.devtools.panels.create(
                         }
                     });
 
+                    // clean up after jumps
                     window.document.addEventListener('rebuild', (e) => {
                         deletedComponents = [];
                         for (let component in componentObject) {
@@ -409,6 +410,11 @@ chrome.devtools.panels.create(
                             const component = componentObject[id].component;
                             const captureStateFunc = component.$capture_state;
                             let componentState = captureStateFunc ? captureStateFunc() : {}; 
+                            if (componentState && !Object.keys(componentState).length) {
+                                if (component.$$.ctx.constructor.name === "Object") {
+                                    componentState = deepClone(component.$$.ctx);
+                                }
+                            }
                             
                             const previousState = stateHistory[jumpIndex];
                             for (let componentId in previousState) {

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -308,13 +308,13 @@ chrome.devtools.panels.create(
                                     snapshotLabel
                                 }
                             })
+                            
+                            // reset arrays
+                            components.splice(0, components.length);
+                            insertedNodes.splice(0, insertedNodes.length);
+                            deletedNodes.splice(0, deletedNodes.length);
+                            snapshotLabel = undefined;
                         }
-
-                        // reset arrays
-                        components.splice(0, components.length);
-                        insertedNodes.splice(0, insertedNodes.length);
-                        deletedNodes.splice(0, deletedNodes.length);
-                        snapshotLabel = undefined;
 
                         // start MutationObserver
                         observer.observe(window.document, {attributes: true, childList: true, subtree: true});
@@ -370,13 +370,13 @@ chrome.devtools.panels.create(
                                     snapshotLabel
                                 }
                             });
-                        }
                         
-                        // reset arrays
-                        components.splice(0, components.length);
-                        insertedNodes.splice(0, insertedNodes.length);
-                        deletedNodes.splice(0, deletedNodes.length);
-                        snapshotLabel = undefined;
+                            // reset arrays
+                            components.splice(0, components.length);
+                            insertedNodes.splice(0, insertedNodes.length);
+                            deletedNodes.splice(0, deletedNodes.length);
+                            snapshotLabel = undefined;
+                        }
                     });
 
                     // listen for devTool messages

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -62,9 +62,21 @@ chrome.devtools.panels.create(
                             return {
                                 name,
                                 value: element.toString()
+                            };
+                        }
+                        else if (element instanceof Element) {
+                            return {
+                                name, 
+                                value: 'DOM Element'
                             }
                         }
                         else if (typeof element === "object") {
+                            if (element.hasOwnProperty('$$')) {
+                                return {
+                                    name,
+                                    value: 'Svelte Component'
+                                }
+                            }
                             if (element.constructor) {
                                 if (element.constructor.name === "Object" || element.constructor.name === "Array") {
                                     const value = {};
@@ -94,13 +106,14 @@ chrome.devtools.panels.create(
                             };
                         }
                     }
+
                     function captureComponentState(component) {
                         const captureStateFunc = component.$capture_state;
                         let state = captureStateFunc ? captureStateFunc() : {};
                         // if capture_state produces an empty object, may need to use ctx instead (older version of Svelte)
                         if (state && !Object.keys(state).length) {
                             if (component.$$.ctx.constructor.name === "Object") {
-                                state = JSON.parse(JSON.stringify(component.$$.ctx));
+                                state = deepClone(component.$$.ctx);
                             }
                         }
                     
@@ -115,7 +128,9 @@ chrome.devtools.panels.create(
                             else if (typeof state[variable] === "object") {
                                 if (state[variable].constructor) {
                                     if (state[variable].constructor.name === "Object" || state[variable].constructor.name === "Array") {
+                                        // check if variable is a store variable
                                         if (state[variable].hasOwnProperty('subscribe')) {
+                                            // if a writable store, we need to store the instance
                                             if (state[variable].hasOwnProperty('set') && state[variable].hasOwnProperty('update')) {
                                                 storeVariables[variable] = state[variable];
                                             }
@@ -203,17 +218,29 @@ chrome.devtools.panels.create(
                         return tagName;
                     }
 
-                    function parseCtxObject() {
-                        parsedCtx = {};
-                        for (let component in ctxObject) {
-                            const ctxData = {};
-                            ctxObject[component].ctx.forEach((element, index) => {
-                                ctxData[index] = parseCtx(element);
-                            })
-                            parsedCtx[component] = ctxData;
+                    const deepClone = (inObject) => {
+                        let outObject, value, key
+                      
+                        if (typeof inObject !== "object" || inObject === null) {
+                          return inObject // Return the value if inObject is not an object
                         }
-                        return parsedCtx;
-                    }
+                      
+                        if (inObject.constructor.name !== "Object" && inObject.constructor.name !== "Array") {
+                            return inObject // Return the value if inObject is not an object
+                        }
+
+                        // Create an array or object to hold the values
+                        outObject = Array.isArray(inObject) ? [] : {}
+                      
+                        for (key in inObject) {
+                          value = inObject[key]
+                      
+                          // Recursively (deep) copy for nested objects, including arrays
+                          outObject[key] = deepClone(value)
+                        }
+                      
+                        return outObject
+                      }
 
                     function updateLabel(nodeId, event) {
                         const listener = listeners[nodeId + event];
@@ -295,7 +322,7 @@ chrome.devtools.panels.create(
                     window.onload = () => {
                         // make sure that data is being sent
                         if (components.length || insertedNodes.length || deletedNodes.length) {
-                            stateHistory.push(JSON.parse(JSON.stringify(captureRawAppState())));
+                            stateHistory.push(deepClone(captureRawAppState()));
                             firstLoadSent = true;
                             
                             window.postMessage({
@@ -351,7 +378,7 @@ chrome.devtools.panels.create(
                         const currentState = captureRawAppState();
                         const stateChange = JSON.stringify(currentState) !== JSON.stringify(stateHistory[stateHistory.length -1]);
                         if (components.length || insertedNodes.length || deletedNodes.length) {
-                            stateHistory.push(JSON.parse(JSON.stringify(currentState)));
+                            stateHistory.push(deepClone(currentState));
                             let type;
                             // make sure the first load has already been sent; if not, this is the first load
                             if (!firstLoadSent) {
@@ -389,7 +416,7 @@ chrome.devtools.panels.create(
                             }
                         }
                         
-                        components.forEach (newComponent => {
+                        components.forEach(newComponent => {
                             const { tagName, id } = newComponent;
                             const component = componentObject[id].component;
                             const captureStateFunc = component.$capture_state;

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -248,9 +248,6 @@ chrome.devtools.panels.create(
                                             }
                                         }
                                     }
-                                    else {
-                                        destroyComponent(componentInstance);
-                                    }
                                 }
                             }
                         })
@@ -362,7 +359,7 @@ chrome.devtools.panels.create(
                         // only send message if something changed in SvelteDOM or stateObject
                         const currentState = captureRawAppState();
                         const stateChange = JSON.stringify(currentState) !== JSON.stringify(stateHistory[stateHistory.length -1]);
-                        if (components.length || insertedNodes.length || deletedNodes.length || stateChange) {
+                        if (components.length || insertedNodes.length || deletedNodes.length) {
                             stateHistory.push(JSON.parse(JSON.stringify(currentState)));
                             let type;
                             // make sure the first load has already been sent; if not, this is the first load

--- a/extension/devtools/index.js
+++ b/extension/devtools/index.js
@@ -423,7 +423,8 @@ chrome.devtools.panels.create(
                                         tagName
                                     }
                                     newComponent.id = componentId;
-                                    delete componentObject[id]
+                                    delete componentObject[id];
+                                    componentCounts[tagName]--;
                                 }
                             }    
                         })

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {snapshots, fileTree, flatFileTree, backgroundPageConnection } from './stores.js';
+	import { snapshots, fileTree, flatFileTree, backgroundPageConnection, sharedAppView } from './stores.js';
 	import { get } from 'svelte/store';
 	import Component from './Component.svelte';
 	import StateChart from './StateChart.svelte';
@@ -26,6 +26,10 @@
 			}
 			jumping = false;
 		}
+	}
+
+	$: {
+		sharedAppView.set(CurrentAppView);
 	}
 
 	let I;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -223,9 +223,17 @@
 			<div id="presentation">
 				{#if $snapshots.length} 
 					{#if View === "files" && Vis === "tree"}
-						<Component component={$fileTree}/>
+						{#if Object.keys($fileTree).length}
+							<Component component={$fileTree}/>
+						{:else}
+							<p>File structure data unavailable</p>
+						{/if}
 					{:else if View === "files" && Vis === "chart"}
-						<FileStructure treeData={$fileTree}/>
+						{#if Object.keys($fileTree).length}
+							<FileStructure treeData={$fileTree}/>
+						{:else}
+							<p>File structure data unavailable</p>
+						{/if}
 					{:else if View === "state"}
 					   {#if Vis === "tree"}
 					    <StateTree I={CurrentI}/>

--- a/src/Diffs.svelte
+++ b/src/Diffs.svelte
@@ -26,7 +26,7 @@
             {#if Object.keys(changedVariables).length} 
                 <h3 class='diffsHeading'>Changed Variables:</h3>
                 {#each Object.entries(changedVariables) as [componentName, component]}
-                    <h4 class='diffComponentName'>{component.id}</h4>
+                    <h4 class='diffComponentName'>{componentName}</h4>
                     <ul>
                     {#each Object.entries(component) as [variableName, variable]} 
                         {#if variable.oldValue !== '' && variable.newValue !== ''}

--- a/src/Diffs.svelte
+++ b/src/Diffs.svelte
@@ -6,8 +6,6 @@
     $: deletedComponents = snapshot.diff.deletedComponents;
     $: changedVariables = snapshot.diff.changedVariables;
 
-    console.log(changedVariables);
-
 </script>
 
 <main>
@@ -25,18 +23,18 @@
                     <h4 class='deletedComponent'>{component.component}</h4>
                 {/each}
             {/if}
-            {#if changedVariables.length} 
+            {#if Object.keys(changedVariables).length} 
                 <h3 class='diffsHeading'>Changed Variables:</h3>
-                {#each changedVariables as component}
-                    <h4 class='diffComponentName'>{component[0].component}</h4>
+                {#each Object.entries(changedVariables) as [componentName, component]}
+                    <h4 class='diffComponentName'>{componentName}</h4>
                     <ul>
-                    {#each component as variable} 
+                    {#each Object.entries(component) as [variableName, variable]} 
                         {#if variable.oldValue !== '' && variable.newValue !== ''}
-                            <li class="oldAndNewVals">{variable.name}: <span class='oldValue'>{variable.oldValue}</span> <span class='newValue'> &#8594; {variable.newValue}</span></li>
+                            <li class="oldAndNewVals">{variableName}: <span class='oldValue'>{variable.oldValue}</span> <span class='newValue'> &#8594; {variable.newValue}</span></li>
                         {:else if variable.oldValue === ''}
-                            <li class="oldAndNewVals">{variable.name}: <span class='oldValue'>' '</span> <span class ='newValue'> &#8594; {variable.newValue}</span></li>
+                            <li class="oldAndNewVals">{variableName}: <span class='oldValue'>' '</span> <span class ='newValue'> &#8594; {variable.newValue}</span></li>
                         {:else if variable.newValue === ''}
-                            <li class="oldAndNewVals">{variable.name}: <span class='oldValue'>{variable.oldValue}</span> <span class='newValue'> &#8594; ' '</span></li>
+                            <li class="oldAndNewVals">{variableName}: <span class='oldValue'>{variable.oldValue}</span> <span class='newValue'> &#8594; ' '</span></li>
                         {/if}
                     {/each}
                     </ul>

--- a/src/Diffs.svelte
+++ b/src/Diffs.svelte
@@ -26,7 +26,7 @@
             {#if Object.keys(changedVariables).length} 
                 <h3 class='diffsHeading'>Changed Variables:</h3>
                 {#each Object.entries(changedVariables) as [componentName, component]}
-                    <h4 class='diffComponentName'>{componentName}</h4>
+                    <h4 class='diffComponentName'>{component.id}</h4>
                     <ul>
                     {#each Object.entries(component) as [variableName, variable]} 
                         {#if variable.oldValue !== '' && variable.newValue !== ''}

--- a/src/StateChart.svelte
+++ b/src/StateChart.svelte
@@ -56,11 +56,9 @@ const height = document.body.clientHeight;
        let treemap = d3.tree().size([width,height]);
        //construct root node
 
-       console.log('tree', tree);
        root = d3.hierarchy(tree, function(d){
            return d.children;
        });
-       console.log('root',root);
        
     root.x0 = 0;
     root.y0 = width/2;
@@ -69,7 +67,6 @@ const height = document.body.clientHeight;
        function update(src){
            let treeData = treemap(root)
            let nodes = treeData.descendants();
-           console.log('nodes',nodes)
 
            //set depth
            nodes.forEach(function(d){
@@ -252,7 +249,6 @@ const height = document.body.clientHeight;
                d._children=null;
            }
            update(d);
-           //console.log(`${d.data.id} node is selected`)
        }
        
        }
@@ -261,9 +257,7 @@ const height = document.body.clientHeight;
     
 
     preElement = document.getElementsByClassName(`${I}`)[0].previousSibling
-    //console.log('pre',preElement)
     currElement= document.getElementsByClassName(`${I}`)
-    //console.log('curr',currElement)
    if(svg.previousSibling){
 
    }

--- a/src/StateTree.svelte
+++ b/src/StateTree.svelte
@@ -7,46 +7,25 @@
     $: data = $snapshots[I].data;
     $: label = $snapshots[I].label;
 
-    $: componentObject = (Object.keys(data).sort().filter(component => data[component].active)).reduce((result, component) => {
-        const { tagName } = data[component];
-        result[tagName] = result[tagName] ?? [];
-        result[tagName].push(component);
-        return result;
-    }, {})
+    $: componentList = (Object.keys(data).sort())
 
 </script>
 
 <main>
     {#if data}
     <h2>Snapshot {I}: {label}</h2>
-        {#each Object.keys(componentObject) as componentGroup} 
-            {#each componentObject[componentGroup] as componentName, i}
-                {#if componentObject[componentGroup].length === 1 }
-                    {#if Object.keys(data[componentName].variables).length}
-                        <CollapsibleSection headerText={data[componentName].tagName}>
-                            <div class="content">
-                            {#each Object.keys(data[componentName].variables) as variable}  
-                                {#if data[componentName].variables[variable].value !==undefined && data[componentName].variables[variable].value !== null}  
-                                    <Variable variable={data[componentName].variables[variable]}/>                
-                                {/if}
-                            {/each}
-                            </div>
-                        </CollapsibleSection>
-                    {/if}    
-                {:else}
-                    {#if Object.keys(data[componentName].variables).length}
-                        <CollapsibleSection headerText={data[componentName].tagName + '[' + i + ']'}>
-                            <div class="content">
-                            {#each Object.keys(data[componentName].variables) as variable}  
-                                {#if data[componentName].variables[variable].value !==undefined && data[componentName].variables[variable].value !== null}  
-                                    <Variable variable={data[componentName].variables[variable]}/>                
-                                {/if}
-                            {/each}
-                            </div>
-                        </CollapsibleSection>
-                    {/if}  
-                {/if}  
-            {/each}
+        {#each componentList as componentName} 
+            {#if Object.keys(data[componentName].variables).length}
+                <CollapsibleSection headerText={data[componentName].id}>
+                    <div class="content">
+                        {#each Object.keys(data[componentName].variables) as variable}  
+                            {#if data[componentName].variables[variable].value !==undefined && data[componentName].variables[variable].value !== null}  
+                                <Variable variable={data[componentName].variables[variable]}/>                
+                            {/if}
+                        {/each}
+                    </div>
+                </CollapsibleSection>
+            {/if}     
         {/each}
     {/if}
 </main>

--- a/src/StateTree.svelte
+++ b/src/StateTree.svelte
@@ -7,7 +7,7 @@
     $: data = $snapshots[I].data;
     $: label = $snapshots[I].label;
 
-    $: componentList = (Object.keys(data).sort())
+    $: componentList = (Object.keys(data).sort().filter(component => data[component].active))
 
 </script>
 

--- a/src/Variable.svelte
+++ b/src/Variable.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <main>
-    {#if typeof variable.value !== "object"}
+    {#if typeof variable.value !== "object" || variable.value === null}
         {#if variable.value === ''}
             <p class="variableVal">{variable.name}: ' '</p>
         {:else}

--- a/src/stores.js
+++ b/src/stores.js
@@ -62,12 +62,12 @@ chrome.devtools.inspectedWindow.getResources(resources => {
 				const components = {};
 				if (ast.instance) {
 					const astVariables = ast.instance.content.body;
-					const data = {};
 					astVariables.forEach(variable => {
+						const data = {};
 						if (variable.type === "ImportDeclaration" && variable.source.value.includes('.svelte')) {
 							data.name = variable.specifiers[0].local.name;
 							data.parent = componentName;
-							components[data.name] = (data);
+							components[data.name] = data;
 						}
 					})
 				}
@@ -298,8 +298,10 @@ function buildSnapshot(data) {
 	let currentTree = get(fileTree);
 	if (_.isEmpty(currentTree)) {
 		// assign component children
+		console.log(astInfo);
+		console.log(componentTree);
 		for (let file in astInfo) {
-			for (let childFile in astInfo[file].components) {
+			for (let childFile in astInfo[file]) {
 				componentTree[file].children.push(componentTree[childFile]);
 				componentTree[childFile].parent = file;
 			}
@@ -315,10 +317,6 @@ function buildSnapshot(data) {
 		if (!_.isEmpty(componentTree)) {
 			fileTree.set(componentTree[parentComponent]);
 		}
-
-
-		// set fileTree for hierarchical displays
-	 	fileTree.set(componentTree[parentComponent]);
 
 		//create depth-first ordering of tree for state injections
 		const flatTreeArray = [];

--- a/src/stores.js
+++ b/src/stores.js
@@ -53,6 +53,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 
 // get and parse through the AST for additional variable info
 chrome.devtools.inspectedWindow.getResources(resources => {
+	console.log(resources);
 	const arrSvelteFiles = resources.filter(file =>file.url.includes(".svelte"));
 	arrSvelteFiles.forEach(svelteFile => {
 	  	svelteFile.getContent(source => {
@@ -89,11 +90,6 @@ function buildSnapshot(data) {
 		deletedComponents: [],
 		changedVariables: {}
 	};
-
-	// delete nodes and descendents
-	deletedNodes.forEach(node => {
-		deleteNode(node.id);
-	})
 
 	// build nodes object
 	insertedNodes.forEach(node => {
@@ -206,6 +202,11 @@ function buildSnapshot(data) {
 				componentData[component].targets[node.id] = true;
 			}
 		}
+	})
+
+	// delete nodes and descendents
+	deletedNodes.forEach(node => {
+		deleteNode(node.id);
 	})
 
 	// determine and assign the DOM parent (can't happen until all components are built and have nodes assigned)

--- a/src/stores.js
+++ b/src/stores.js
@@ -239,20 +239,22 @@ function buildSnapshot(data) {
 					component.variables[varName].value = value;
 				}
 
-				// if variable is in stateObject but not in stateHistory, old value is null
-				if (!stateHistory[componentId].variables.hasOwnProperty(varName)) {
-					data = {
-						name: varName,
-						oldValue: null,
-						newValue: getDiffValue(value),
+				if (stateHistory.hasOwnProperty(componentId)) {
+					// if variable is in stateObject but not in stateHistory, old value is null
+					if (!stateHistory[componentId].variables.hasOwnProperty(varName)) {
+						data = {
+							name: varName,
+							oldValue: null,
+							newValue: getDiffValue(value),
+						}
 					}
-				}
-				// if values are different in stateObject and stateHistory, set old and new values respetively
-				else if (!(_.isEqual(stateHistory[componentId].variables[varName].value, value))) {
-					data = {
-						name: varName,
-						oldValue: stateHistory[componentId].variables[varName].value !== undefined ? getDiffValue(stateHistory[componentId].variables[varName].value) : "undefined",
-						newValue: getDiffValue(value),
+					// if values are different in stateObject and stateHistory, set old and new values respetively
+					else if (!(_.isEqual(stateHistory[componentId].variables[varName].value, value))) {
+						data = {
+							name: varName,
+							oldValue: stateHistory[componentId].variables[varName].value !== undefined ? getDiffValue(stateHistory[componentId].variables[varName].value) : "undefined",
+							newValue: getDiffValue(value),
+						}
 					}
 				}
 			
@@ -274,19 +276,21 @@ function buildSnapshot(data) {
 				}
 			}
 			
-			for (let [varName, variable] of Object.entries(stateHistory[componentId].variables)) {
-				// if variable is in stateHistory but not in stateObject, new value is null
-				if (!stateObject[componentId].hasOwnProperty(varName)) {
-					const data = {
-						name: varName,
-						oldValue: variable.value !== undefined ? getDiffValue(variable.value) : "undefined",
-						newValue: null,
-					}
-					if (varName[0] === '$') {
-						storeDiff[varName] = data;
-					}
-					else {
-						componentDiff[varName] = data;
+			if (stateHistory.hasOwnProperty(componentId)) {
+				for (let [varName, variable] of Object.entries(stateHistory[componentId].variables)) {
+					// if variable is in stateHistory but not in stateObject, new value is null
+					if (!stateObject[componentId].hasOwnProperty(varName)) {
+						const data = {
+							name: varName,
+							oldValue: variable.value !== undefined ? getDiffValue(variable.value) : "undefined",
+							newValue: null,
+						}
+						if (varName[0] === '$') {
+							storeDiff[varName] = data;
+						}
+						else {
+							componentDiff[varName] = data;
+						}
 					}
 				}
 			}

--- a/src/stores.js
+++ b/src/stores.js
@@ -416,7 +416,7 @@ function getDiffValue(value) {
 			for (let i = 1; i <= tabCount; i++) {
 				text = text + "\t"
 			}
-			text = text + obj.name + ":";
+			text = text + obj.name + ": ";
 			if (typeof obj.value !=='object') {
 				text = text + obj.value + "\n";
 			}

--- a/src/stores.js
+++ b/src/stores.js
@@ -186,7 +186,6 @@ function buildSnapshot(data) {
 
 	// if DOM was rebuilt by jumping, need to explicitly remove components
 	if (rebuild) {
-		console.log(data.deletedComponents);
 		data.deletedComponents.forEach(component => {
 			delete componentData[component];
 		})
@@ -220,8 +219,6 @@ function buildSnapshot(data) {
 
 	// update state variables
 	const storeDiff = {};
-	console.log(stateObject);
-	console.log(componentData);
 	for (let component in componentData) {
 		const componentDiff = {};
 		for(let i in componentData[component].variables) {
@@ -253,7 +250,7 @@ function buildSnapshot(data) {
 					data = {
 						name: variable,
 						oldValue: null,
-						newValue: getDiffValue(stateObject[component][variable.name].value),
+						newValue: getDiffValue(stateObject[component][variable].value),
 					}
 					componentData[component].variables.variable = stateObject[component][variable];
 				}

--- a/src/stores.js
+++ b/src/stores.js
@@ -312,16 +312,27 @@ function buildSnapshot(data) {
 			}
 		}
 
+		if (!_.isEmpty(componentTree)) {
+			fileTree.set(componentTree[parentComponent]);
+		}
+
+
 		// set fileTree for hierarchical displays
 	 	fileTree.set(componentTree[parentComponent]);
 
 		//create depth-first ordering of tree for state injections
 		const flatTreeArray = [];
 
-		depthFirstTraverse(componentTree[parentComponent]);
+		// if AST came through, make flat file tree based on that; otherwise use componentData
+		if (!_.isEmpty(componentTree)) {
+			depthFirstTraverse(componentTree[parentComponent]);
+		}
+		else {
+			depthFirstTraverse(componentData[domParent]);
+		}
 		
 		function depthFirstTraverse(tree) {
-			flatTreeArray.push(tree.id);
+			flatTreeArray.push(tree.tagName || tree.id);
 			if (tree.children.length) {
 				tree.children.forEach(child => {
 					depthFirstTraverse(child);

--- a/src/stores.js
+++ b/src/stores.js
@@ -237,20 +237,15 @@ function buildSnapshot(data) {
 
 	// update state variables
 	const currentIndex = get(sharedAppView);
+	console.log(currentIndex);
 	if (currentIndex >= 0) {
 		const allStates = get(snapshots);
 		const stateHistory = allStates[currentIndex].data;
+		console.log(allStates[currentIndex]);
 		const storeDiff = {};
-
-		console.log(componentData);
-		console.log(Object.values(componentData));
-		console.log(Object.entries(componentData));
 
 		for (let [componentId, component] of Object.entries(componentData)) {
 			const componentDiff = {};
-
-			console.log(componentId);
-			console.log(component);
 
 			for (let [varName, variable] of Object.entries(stateObject[componentId])) {
 				const { name, value } = variable;
@@ -317,7 +312,7 @@ function buildSnapshot(data) {
 			}
 		
 			if (!_.isEmpty(componentDiff)) {
-				diff.changedVariables[component] = componentDiff;
+				diff.changedVariables[componentId] = componentDiff;
 			}	
 		}
 


### PR DESCRIPTION
Under the hood changes that switch devtool's primary data source from Svelte's "ctx" to instead utilize "$capture_state." 

Our old implementation relied on both the ctx and data drawn from the AST to parse variables in state. It also relied on string manipulation and the assumption that store variables would always be sourced from a file with "store" in the file name. Using "$capture_state" instead allows us to fully separate state from the AST, which is important so that part of the tool still works even if the AST data is unavailable. It also allows us to recognize store variables regardless of what the name of their source file is.

This version should be more robust and generalizable. All existing features should work as previously on sites they already worked on, and should now work on some sites that they didn't previously work on.