### PR TITLE
Add functionality to create snapshot labels from AddEventListener events

### DIFF
--- a/extension/devtools/src/DataStore.js
+++ b/extension/devtools/src/DataStore.js
@@ -6,6 +6,7 @@ export default class DataStore {
   constructor() {
     this.componentInstances = {}; // Map with keys of component ID's and values of references to component instances
     this.componentRepresentations = {}; // Map with keys of component ID's and values of component representations
+    this.snapshotLabel = "Initial Load";
   }
 
   /**
@@ -40,5 +41,21 @@ export default class DataStore {
    */
   getComponentRepresentations() {
     return this.componentRepresentations;
+  }
+
+  /**
+   * Updates snapshot label to reflect most recent user interaction
+   * @param {string} label Label for next snapshot
+   */
+  setLabel(label) {
+    this.snapshotLabel = label;
+  }
+
+  /**
+   * Get the current snapshot label.
+   * @returns {string}  The current label (data on most recent user interaction).
+   */
+  getLabel() {
+    return this.snapshotLabel;
   }
 }

--- a/extension/devtools/src/Router.js
+++ b/extension/devtools/src/Router.js
@@ -23,6 +23,10 @@ export default class Router {
       this.parser.handleRegisterComponent(e);
     });
 
+    window.addEventListener("SvelteDOMAddEventListener", (e) => {
+      this.addAppEventListener(e);
+    });
+
     //on completion of initial page load, capture first state snapshot and start watching for subsequent DOM updates
     window.addEventListener("load", () => {
       this.producer.processDOMUpdate();
@@ -45,5 +49,22 @@ export default class Router {
       subtree: true,
       characterData: true,
     });
+  }
+
+  /**
+   * Creates event listener on node in user app mirroring a newly added within-app listener.
+   *
+   * This function handles a SvelteAddEventListener event by adding a listener corresponding to the in-app listener that will
+   * send data about this particular user interaction to the SvelteEventParser. This data will be used by the Parser to label
+   * the snapshot representing changes related to this user interaction with the event type that was fired, the component where
+   * interaction originated, and the name of the handler function that triggered the state change.
+   *
+   * @param {*} e
+   */
+  addAppEventListener(e) {
+    const { event, handler, node } = e.detail;
+    node.addEventListener(event, () =>
+      this.parser.processAppEvent(node, event, handler)
+    );
   }
 }

--- a/extension/devtools/src/SvelteEventParser.js
+++ b/extension/devtools/src/SvelteEventParser.js
@@ -49,4 +49,22 @@ export default class SvelteEventParser {
     const instanceNumber = (this.componentCounts[tagName] || 0) + 1;
     return instanceNumber;
   }
+
+  processAppEvent(node, event, handler) {
+    const component = this.getComponentTagName(node);
+    const handlerName = handler.name;
+    const label = component + " - " + event + " -> " + handlerName;
+    this.dataStore.setLabel(label);
+  }
+
+  getComponentTagName(node) {
+    const fileName = node.__svelte_meta.loc.file;
+    // if this is a Windows based file naming, ie. \ instead of /
+    if (fileName.indexOf("/") === -1) {
+      return fileName.slice(fileName.lastIndexOf("\\\\") + 1, -7);
+    }
+
+    // else Mac/Linux based file naming, use / as separator
+    return fileName.slice(fileName.lastIndexOf("/") + 1, -7);
+  }
 }

--- a/testing/mocks/appEntries/TestApp8.svelte
+++ b/testing/mocks/appEntries/TestApp8.svelte
@@ -1,0 +1,19 @@
+<script>
+  /*
+  App with three child descendents.
+  
+                TestApp1
+                    |
+                SubChild1
+                    |
+                  Child1
+                    |
+                LeafChild1
+*/
+
+  import SubChild from "../components/SubChild.svelte";
+</script>
+
+<main>
+  <SubChild />
+</main>

--- a/testing/mocks/components/LeafChild.svelte
+++ b/testing/mocks/components/LeafChild.svelte
@@ -1,6 +1,13 @@
 <script>
+  function clickHandlerOne() {
+    console.log("Button One clicked");
+  }
+  function clickHandlerTwo() {
+    console.log("Button Two clicked");
+  }
 </script>
 
 <main>
-  <p>Hello World</p>
+  <button on:click={clickHandlerOne} class="button-one"> Click me </button>
+  <button on:click={clickHandlerTwo} class="button-two"> Click me </button>
 </main>

--- a/testing/mocks/components/LeafChild.svelte
+++ b/testing/mocks/components/LeafChild.svelte
@@ -1,13 +1,16 @@
 <script>
-  function clickHandlerOne() {
-    console.log("Button One clicked");
+  $: text = null;
+
+  function clickHandler() {
+    text = "Click Handled";
   }
-  function clickHandlerTwo() {
-    console.log("Button Two clicked");
+  function inputHandler() {
+    text = "Input Handled!";
   }
 </script>
 
 <main>
-  <button on:click={clickHandlerOne} class="button-one"> Click me </button>
-  <button on:click={clickHandlerTwo} class="button-two"> Click me </button>
+  <button on:click={clickHandler}> Click me </button>
+  <input type="text" on:input={inputHandler} />
+  <p>{text}</p>
 </main>

--- a/testing/mocks/components/SubChild.svelte
+++ b/testing/mocks/components/SubChild.svelte
@@ -1,0 +1,7 @@
+<script>
+  import Child from "./Child.svelte";
+</script>
+
+<main>
+  <Child />
+</main>

--- a/testing/mocks/testData.js
+++ b/testing/mocks/testData.js
@@ -5,6 +5,7 @@ import TestApp4 from "./appEntries/TestApp4.svelte";
 import TestApp5 from "./appEntries/TestApp5.svelte";
 import TestApp6 from "./appEntries/TestApp6.svelte";
 import TestApp7 from "./appEntries/TestApp7.svelte";
+import TestApp8 from "./appEntries/TestApp8.svelte";
 
 export const testData = [
   {
@@ -91,8 +92,21 @@ export const testData = [
       totalComponents: 4,
       componentIds: ["TestApp71", "Child1", "LeafChild1", "LeafChild2"],
       children: {
-        TestApp51: ["Child1", "LeafChild1"],
+        TestApp71: ["Child1", "LeafChild1"],
         Child1: ["LeafChild2"],
+      },
+    },
+  },
+  {
+    name: "TestApp8",
+    app: TestApp8.default,
+    data: {
+      totalComponents: 4,
+      componentIds: ["TestApp81", "Child1", "LeafChild1", "SubChild1"],
+      children: {
+        TestApp51: ["SubChild1"],
+        SubChild1: ["Child1"],
+        Child1: ["LeafChild1"],
       },
     },
   },

--- a/testing/tests/SvelteEventParser.test.js
+++ b/testing/tests/SvelteEventParser.test.js
@@ -55,17 +55,21 @@ describe.each(testData)("$name", (testApp) => {
 
   describe("AddEventListenerEvents", () => {
     it("Correctly updates snapshot label based on user event", () => {
-      const buttonOneList = appWindow.document.querySelectorAll(".button-one");
-      const buttonTwoList = appWindow.document.querySelectorAll(".button-two");
-      buttonOneList.forEach((button) => {
+      const buttonList = appWindow.document.querySelectorAll("button");
+      const inputList = appWindow.document.querySelectorAll("input");
+      expect(dataStore.snapshotLabel).toMatch("Initial Load");
+      buttonList.forEach((button) => {
         button.click();
-        expect(dataStore.snapshotLabel).toMatch(/(- click -> clickHandlerOne)/);
-        expect(dataStore.snapshotLabel).toMatch(/(LeafChild)/);
+        expect(dataStore.snapshotLabel).toMatch(
+          "LeafChild - click -> clickHandler"
+        );
       });
-      buttonTwoList.forEach((button) => {
-        button.click();
-        expect(dataStore.snapshotLabel).toMatch(/(- click -> clickHandlerTwo)/);
-        expect(dataStore.snapshotLabel).toMatch(/(LeafChild)/);
+      inputList.forEach((input) => {
+        const inputEvent = new Event("input");
+        input.dispatchEvent(inputEvent);
+        expect(dataStore.snapshotLabel).toMatch(
+          "LeafChild - input -> inputHandler"
+        );
       });
     });
   });

--- a/testing/tests/SvelteEventParser.test.js
+++ b/testing/tests/SvelteEventParser.test.js
@@ -12,10 +12,12 @@ const context = new TestAppContext();
 describe.each(testData)("$name", (testApp) => {
   const expected = testApp.data;
   let dataStore; // can't be assigned until router instance is created and stored in the context
+  let appWindow;
 
   beforeAll(async () => {
     await context.testSetUp(testApp.app);
     dataStore = context.router.dataStore; // reassign after set up to bring data from router instance into "describe" scope
+    appWindow = context.appWindow;
     return;
   });
 
@@ -48,6 +50,23 @@ describe.each(testData)("$name", (testApp) => {
       expect(components.length).toBe(totalComponents);
       expect(components).toEqual(expect.arrayContaining(componentIds));
       expect(instance).toBeInstanceOf(SvelteComponent);
+    });
+  });
+
+  describe("AddEventListenerEvents", () => {
+    it("Correctly updates snapshot label based on user event", () => {
+      const buttonOneList = appWindow.document.querySelectorAll(".button-one");
+      const buttonTwoList = appWindow.document.querySelectorAll(".button-two");
+      buttonOneList.forEach((button) => {
+        button.click();
+        expect(dataStore.snapshotLabel).toMatch(/(- click -> clickHandlerOne)/);
+        expect(dataStore.snapshotLabel).toMatch(/(LeafChild)/);
+      });
+      buttonTwoList.forEach((button) => {
+        button.click();
+        expect(dataStore.snapshotLabel).toMatch(/(- click -> clickHandlerTwo)/);
+        expect(dataStore.snapshotLabel).toMatch(/(LeafChild)/);
+      });
     });
   });
 });

--- a/testing/utils/TestAppContext.js
+++ b/testing/utils/TestAppContext.js
@@ -11,7 +11,7 @@ export default class TestAppContext {
    * Creates a TestAppContext object
    */
   constructor() {
-    this.app = null;
+    this.appWindow = null;
     this.router = null;
     this.registrator = GlobalRegistrator;
   }
@@ -19,6 +19,7 @@ export default class TestAppContext {
   async testSetUp(appInstance) {
     // create a happy-dom instance and registers it globally
     this.registrator.register();
+    this.appWindow = window;
 
     // create the router instance and store it
     this.router = init();


### PR DESCRIPTION
This PR adds functionality that captures user events and creates a label made up of the event's relevant component, event type and handler function name. This label is saved in the DataStore, where it will be retrieved as the label for the next snapshot when MutationObserver events trigger snapshot capture.

**Testing**
To test, make sure that all scripts are still running properly. All automated tests should pass. For manual verification on an actual application in the browser, run this version on a running Svelte app. User interactions (e.g., adding or deleting a feedback item) should produce all previous output (three logs for each interaction: component instances, component representations, and "capture snapshot" string) but now the "capture snapshot" string should also display the correct label for the given snapshot.

**Overview of Changes**
A snapshotLabel property is added to the DataStore class with associated getter and setter functions.

In the Router class, a new event listener is added for SvelteAddEventListener events, along with a new handler function that takes the details of the newly added event listener and creates a new listener for those specific events that calls a handler in the SvelteEventParser class.

The SvelteEventParser class has a new function to handle user events by parsing them into labels and sending them to the DataStore for storage. A helper function gets the component tagname from a component's filename, which is carried in the __svelte_meta__ property of DOM nodes included in the event listener details.

To facilitate automated testing, some new mock app components have been added that include button and input fields and related handlers, and test have been added that mock user interactions and check for appropriate labels being stored.

Finally, a new mock app has been added that included three levels of descendents, and related data included for testing.
