### PR TITLE
Hb encapsulate private fields

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
   extends: "eslint:recommended",
 
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: "latest",
     sourceType: "module",
   },
   env: {

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
-{ 
-    "*.{js, svelte}": "eslint",
-    "*.{js,svelte,json,css,html,yml}": ["prettier --check"] 
+{
+  "*.{js, svelte}": "eslint",
+  "*.{js,svelte,json,css,html,yml}": ["prettier --check"]
 }

--- a/extension/devtools/src/DataStore.js
+++ b/extension/devtools/src/DataStore.js
@@ -1,12 +1,16 @@
 /** Class responsible for storing and sharing data for snapshot production and state injections. */
 export default class DataStore {
+  #componentInstances;
+  #componentRepresentations;
+  #snapshotLabel;
+
   /**
    * Creates a DataStore object.
    */
   constructor() {
-    this.componentInstances = {}; // Map with keys of component ID's and values of references to component instances
-    this.componentRepresentations = {}; // Map with keys of component ID's and values of component representations
-    this.snapshotLabel = "Initial Load";
+    this.#componentInstances = {}; // Map with keys of component ID's and values of references to component instances
+    this.#componentRepresentations = {}; // Map with keys of component ID's and values of component representations
+    this.#snapshotLabel = "Initial Load";
   }
 
   /**
@@ -15,7 +19,7 @@ export default class DataStore {
    * @param {SvelteComponent} instance    The reference to the component instance.
    */
   insertComponentInstance(id, instance) {
-    this.componentInstances[id] = instance;
+    this.#componentInstances[id] = instance;
   }
 
   /**
@@ -24,7 +28,7 @@ export default class DataStore {
    * @param {ComponentRepresentation} representation  The map of component properties to be sent to UI.
    */
   insertComponentRepresentation(id, representation) {
-    this.componentRepresentations[id] = representation;
+    this.#componentRepresentations[id] = representation;
   }
 
   /**
@@ -32,7 +36,7 @@ export default class DataStore {
    * @returns { Object }  Map with keys of component ID's and value of component representations
    */
   getComponentInstances() {
-    return this.componentInstances;
+    return this.#componentInstances;
   }
 
   /**
@@ -40,7 +44,7 @@ export default class DataStore {
    * @returns { Object }  Map with keys of component ID's and values of component representations
    */
   getComponentRepresentations() {
-    return this.componentRepresentations;
+    return this.#componentRepresentations;
   }
 
   /**
@@ -48,7 +52,7 @@ export default class DataStore {
    * @param {string} label Label for next snapshot
    */
   setLabel(label) {
-    this.snapshotLabel = label;
+    this.#snapshotLabel = label;
   }
 
   /**
@@ -56,6 +60,6 @@ export default class DataStore {
    * @returns {string}  The current label (data on most recent user interaction).
    */
   getLabel() {
-    return this.snapshotLabel;
+    return this.#snapshotLabel;
   }
 }

--- a/extension/devtools/src/Router.js
+++ b/extension/devtools/src/Router.js
@@ -4,43 +4,51 @@ import SvelteEventParser from "./SvelteEventParser.js";
 
 /**  Class responsible for listening for and routing events within the user context. */
 export default class Router {
+  #parser;
+  #producer;
+  #dataStore;
+
   /**
    * Creates a Router object
    */
   constructor() {
-    this.dataStore = new DataStore();
-    this.parser = new SvelteEventParser(this.dataStore);
-    this.producer = new SnapshotProducer(this.dataStore);
-    this.addEventListeners();
+    this.#dataStore = new DataStore();
+    this.#parser = new SvelteEventParser(this.#dataStore);
+    this.#producer = new SnapshotProducer(this.#dataStore);
+    this.#addEventListeners();
+  }
+
+  getDataStore() {
+    return this.#dataStore;
   }
 
   /**
    * Initializes event listeners on the window object.
    *
    */
-  addEventListeners() {
+  #addEventListeners() {
     window.addEventListener("SvelteRegisterComponent", (e) => {
-      this.parser.handleRegisterComponent(e);
+      this.#parser.handleRegisterComponent(e);
     });
 
     window.addEventListener("SvelteDOMAddEventListener", (e) => {
-      this.addAppEventListener(e);
+      this.#addAppEventListener(e);
     });
 
     //on completion of initial page load, capture first state snapshot and start watching for subsequent DOM updates
     window.addEventListener("load", () => {
-      this.producer.processDOMUpdate();
-      this.startMutationObserver();
+      this.#producer.processDOMUpdate();
+      this.#startMutationObserver();
     });
   }
 
   /**
    * Creates MutationObserver and configures to begin watching for DOM changes
    */
-  startMutationObserver() {
+  #startMutationObserver() {
     const observer = new MutationObserver(() => {
       // on completion of each set of DOM updates, capture a new state snapshot
-      this.producer.processDOMUpdate();
+      this.#producer.processDOMUpdate();
     });
 
     observer.observe(window.document, {
@@ -61,10 +69,10 @@ export default class Router {
    *
    * @param {*} e
    */
-  addAppEventListener(e) {
+  #addAppEventListener(e) {
     const { event, handler, node } = e.detail;
     node.addEventListener(event, () =>
-      this.parser.processAppEvent(node, event, handler)
+      this.#parser.processAppEvent(node, event, handler)
     );
   }
 }

--- a/extension/devtools/src/SnapshotProducer.js
+++ b/extension/devtools/src/SnapshotProducer.js
@@ -1,11 +1,13 @@
 /** Class that compiles current state data and packages and transmits snapshot. */
 export default class SnapshotProducer {
+  #dataStore;
+
   /**
    * Create a SnapshotProducer object
    * @param {DataStore} dataStore The instance of DataStore shared by the system.
    */
   constructor(dataStore) {
-    this.dataStore = dataStore;
+    this.#dataStore = dataStore;
   }
 
   /**
@@ -15,18 +17,19 @@ export default class SnapshotProducer {
     // verify that this is actually a new state
     // if it is...
     // create a new snapshot object
-    this.createSnapshot();
+    this.#createSnapshot();
     // send snapshot object to devtool context
     // store copy of current state in DataStore's stateHistory
     // reset system to prepare for next snapshot capture
+    this.#reset();
   }
 
   /**
    * Eventually... Package current state data into a snapshot object
    * Currently... Collects current state data and logs to console.
    */
-  createSnapshot() {
-    const { instances, representations, label } = this.getSnapshotData();
+  #createSnapshot() {
+    const { instances, representations, label } = this.#getSnapshotData();
 
     console.log(instances);
     console.log(representations);
@@ -36,11 +39,19 @@ export default class SnapshotProducer {
   /**
    * Get snapshot data from DataStore..
    */
-  getSnapshotData() {
-    const instances = this.dataStore.getComponentInstances();
-    const representations = this.dataStore.getComponentRepresentations();
-    const label = this.dataStore.getLabel();
+  #getSnapshotData() {
+    const instances = this.#dataStore.getComponentInstances();
+    const representations = this.#dataStore.getComponentRepresentations();
+    const label = this.#dataStore.getLabel();
 
     return { instances, representations, label };
+  }
+
+  /**
+   * Reset system in preparation for the next snapshot capture.
+   */
+  #reset() {
+    // set the default label for next snapshot
+    this.#dataStore.setLabel("Application Event");
   }
 }

--- a/extension/devtools/src/SnapshotProducer.js
+++ b/extension/devtools/src/SnapshotProducer.js
@@ -9,10 +9,16 @@ export default class SnapshotProducer {
   }
 
   /**
-   * Collect data from DataStore to create snapshot.
+   * Respond to DOMUpdate events. (Still a work in progress! Comments outline future functionality...)
    */
   processDOMUpdate() {
+    // verify that this is actually a new state
+    // if it is...
+    // create a new snapshot object
     this.createSnapshot();
+    // send snapshot object to devtool context
+    // store copy of current state in DataStore's stateHistory
+    // reset system to prepare for next snapshot capture
   }
 
   /**
@@ -28,7 +34,7 @@ export default class SnapshotProducer {
   }
 
   /**
-   * Collect data from DataStore to create snapshot.
+   * Get snapshot data from DataStore..
    */
   getSnapshotData() {
     const instances = this.dataStore.getComponentInstances();

--- a/extension/devtools/src/SnapshotProducer.js
+++ b/extension/devtools/src/SnapshotProducer.js
@@ -20,11 +20,11 @@ export default class SnapshotProducer {
    * Currently... Collects current state data and logs to console.
    */
   createSnapshot() {
-    const { instances, representations } = this.getSnapshotData();
+    const { instances, representations, label } = this.getSnapshotData();
 
     console.log(instances);
     console.log(representations);
-    console.log("capture snapshot");
+    console.log("capture snapshot - " + label);
   }
 
   /**
@@ -33,7 +33,8 @@ export default class SnapshotProducer {
   getSnapshotData() {
     const instances = this.dataStore.getComponentInstances();
     const representations = this.dataStore.getComponentRepresentations();
+    const label = this.dataStore.getLabel();
 
-    return { instances, representations };
+    return { instances, representations, label };
   }
 }

--- a/extension/devtools/src/SvelteEventParser.js
+++ b/extension/devtools/src/SvelteEventParser.js
@@ -1,14 +1,18 @@
 /** Class responsible for processing data from Svelte produced events. */
 
 export default class SvelteEventParser {
+  #dataStore;
+  #componentCounts;
+  #newComponents;
+
   /**
    * Creates a SvelteEventParser object.
    * @param {DataStore} dataStore The instance of DataStore shared by the system.
    */
   constructor(dataStore) {
-    this.dataStore = dataStore; // dataStore instance to write to
-    this.componentCounts = {}; // map of counts of instances for each component tagName
-    this.newComponents = []; // sequence of component registrations (post-order traversal of overall component hierarchy)
+    this.#dataStore = dataStore; // dataStore instance to write to
+    this.#componentCounts = {}; // map of counts of instances for each component tagName
+    this.#newComponents = []; // sequence of component registrations (post-order traversal of overall component hierarchy)
   }
 
   /**
@@ -17,12 +21,12 @@ export default class SvelteEventParser {
    */
   handleRegisterComponent(event) {
     const { component, tagName } = event.detail;
-    const instanceNumber = this.assignInstanceNumber(tagName);
-    const id = this.assignComponentId(tagName, instanceNumber);
+    const instanceNumber = this.#assignInstanceNumber(tagName);
+    const id = this.#assignComponentId(tagName, instanceNumber);
 
-    this.componentCounts[tagName] = instanceNumber;
-    this.dataStore.insertComponentInstance(id, component);
-    this.dataStore.insertComponentRepresentation(id, {
+    this.#componentCounts[tagName] = instanceNumber;
+    this.#dataStore.insertComponentInstance(id, component);
+    this.#dataStore.insertComponentRepresentation(id, {
       id,
       tagName,
       children: [],
@@ -34,7 +38,7 @@ export default class SvelteEventParser {
    * @param {string}    tagName   The component's "tagName" e.g., the name of the source file where it is defined and exported.
    * @returns {string}            The id of the component - concatenation of tagName and instance number.
    */
-  assignComponentId(tagName, instanceNumber) {
+  #assignComponentId(tagName, instanceNumber) {
     const id = tagName + instanceNumber;
     return id;
   }
@@ -45,19 +49,20 @@ export default class SvelteEventParser {
    * @param {string} tagName  The component's "tagName" e.g., the name of the source file where it is defined and exported.
    * @return {number}         The instance number - one-indexed, based on how many components of same tagName have been registered previously.
    */
-  assignInstanceNumber(tagName) {
-    const instanceNumber = (this.componentCounts[tagName] || 0) + 1;
+  #assignInstanceNumber(tagName) {
+    const instanceNumber = (this.#componentCounts[tagName] || 0) + 1;
     return instanceNumber;
   }
 
   processAppEvent(node, event, handler) {
-    const component = this.getComponentTagName(node);
-    const handlerName = handler.name;
-    const label = component + " - " + event + " -> " + handlerName;
-    this.dataStore.setLabel(label);
+    const componentTagName = this.#getComponentTagName(node);
+    const handlerName = this.#getHandlerName(handler);
+    const label = componentTagName + " - " + event + " -> " + handlerName;
+
+    this.#dataStore.setLabel(label);
   }
 
-  getComponentTagName(node) {
+  #getComponentTagName(node) {
     const fileName = node.__svelte_meta.loc.file;
     // if this is a Windows based file naming, ie. \ instead of /
     if (fileName.indexOf("/") === -1) {
@@ -66,5 +71,9 @@ export default class SvelteEventParser {
 
     // else Mac/Linux based file naming, use / as separator
     return fileName.slice(fileName.lastIndexOf("/") + 1, -7);
+  }
+
+  #getHandlerName(handler) {
+    return handler.name ? handler.name : "anonymous handler";
   }
 }

--- a/testing/tests/SvelteEventParser.test.js
+++ b/testing/tests/SvelteEventParser.test.js
@@ -16,7 +16,7 @@ describe.each(testData)("$name", (testApp) => {
 
   beforeAll(async () => {
     await context.testSetUp(testApp.app);
-    dataStore = context.router.dataStore; // reassign after set up to bring data from router instance into "describe" scope
+    dataStore = context.dataStore; // reassign after set up to bring data from router instance into "describe" scope
     appWindow = context.appWindow;
     return;
   });
@@ -27,7 +27,7 @@ describe.each(testData)("$name", (testApp) => {
 
   describe("Handle RegisterComponent events", () => {
     it("Adds new component representations to componentRepresentations map", () => {
-      const { componentRepresentations } = dataStore;
+      const componentRepresentations = dataStore.getComponentRepresentations();
       const components = Object.keys(componentRepresentations);
       const representation = componentRepresentations[components[0]];
       const { totalComponents, componentIds } = expected;
@@ -43,7 +43,7 @@ describe.each(testData)("$name", (testApp) => {
     });
 
     it("Adds new component instances to componentInstances map", () => {
-      const { componentInstances } = dataStore;
+      const componentInstances = dataStore.getComponentInstances();
       const components = Object.keys(componentInstances);
       const instance = componentInstances[components[0]];
       const { totalComponents, componentIds } = expected;
@@ -57,17 +57,17 @@ describe.each(testData)("$name", (testApp) => {
     it("Correctly updates snapshot label based on user event", () => {
       const buttonList = appWindow.document.querySelectorAll("button");
       const inputList = appWindow.document.querySelectorAll("input");
-      expect(dataStore.snapshotLabel).toMatch("Initial Load");
+      expect(dataStore.getLabel()).toMatch("Application Event");
       buttonList.forEach((button) => {
         button.click();
-        expect(dataStore.snapshotLabel).toMatch(
+        expect(dataStore.getLabel()).toMatch(
           "LeafChild - click -> clickHandler"
         );
       });
       inputList.forEach((input) => {
         const inputEvent = new Event("input");
         input.dispatchEvent(inputEvent);
-        expect(dataStore.snapshotLabel).toMatch(
+        expect(dataStore.getLabel()).toMatch(
           "LeafChild - input -> inputHandler"
         );
       });

--- a/testing/utils/TestAppContext.js
+++ b/testing/utils/TestAppContext.js
@@ -12,7 +12,7 @@ export default class TestAppContext {
    */
   constructor() {
     this.appWindow = null;
-    this.router = null;
+    this.dataStore = null;
     this.registrator = GlobalRegistrator;
   }
 
@@ -22,7 +22,7 @@ export default class TestAppContext {
     this.appWindow = window;
 
     // create the router instance and store it
-    this.router = init();
+    this.dataStore = init();
 
     // create the app instance and store it
     this.app = new appInstance({ target: document.body });

--- a/testing/utils/testMain.js
+++ b/testing/utils/testMain.js
@@ -10,5 +10,6 @@ import Router from "../../extension/devtools/src/Router.js";
  * Instantiates a Router object and returns it.
  */
 export function init() {
-  return new Router();
+  const router = new Router();
+  return router.getDataStore();
 }


### PR DESCRIPTION
This PR is intended to implement best practices around encapsulation of fields within classes that are "private" - ie., they should not be callable from outside the class itself. This should provide some additional security and maintainability within the tool.

There should be no changes to functionality as a result of this PR. All tests should still pass, and in-app logging should be the same as in the previous PR.